### PR TITLE
Fixes status update on newer wink v1 firmwares.

### DIFF
--- a/wink-mqtt.js
+++ b/wink-mqtt.js
@@ -42,6 +42,9 @@ tail.on('line', function(data) {
     if (data.indexOf('state changed in device') > 0) {
         checkDatabase();
     }
+	if (data.indexOf('Received Notification Report') > 0) {
+        checkDatabase();
+    }
 });
 
 tail.on('error', function(data) {


### PR DESCRIPTION
The message in all.log for zWave status changes has changed, causes
statuses not to update. Includes a fix fro the new messages.